### PR TITLE
Improve web search: 3-provider fallback chain and robust tool-call handling

### DIFF
--- a/backend/chatapp/src/main/java/com/example/chatapp/engine/OllamaChatEngine.java
+++ b/backend/chatapp/src/main/java/com/example/chatapp/engine/OllamaChatEngine.java
@@ -79,12 +79,35 @@ public class OllamaChatEngine implements ChatEngine {
     public static final String ERROR_COMMUNICATING = "Error communicating with Ollama API";
   }
 
+  /**
+   * Tool-use hint prepended to every system message when tools are registered. Guides smaller
+   * models (e.g. llama3.2 3B) that otherwise echo the parameter schema as argument values.
+   */
+  private static final String TOOL_USAGE_HINT =
+      "You have access to tools, but you must only use them when truly necessary.\n"
+          + "Do NOT call any tool for: greetings, small talk, simple facts, math, coding"
+          + " questions, or anything you can answer confidently from your training data.\n"
+          + "Only call a tool (e.g. web_search) when the user explicitly needs current,"
+          + " real-time, or external information that you cannot reliably provide yourself.\n"
+          + "When you do call a tool, always supply plain scalar values as arguments — never"
+          + " the schema definition. Example: {\"query\": \"your actual search terms\"},"
+          + " not {\"query\": {\"type\": \"string\", \"description\": \"...\"}}.\n";
+
   private List<Map<String, String>> buildMessagesWithSystemPrompt(final String sessionId) {
     final List<Map<String, String>> context = chatContextService.getContext(sessionId);
-    final String systemPrompt = chatContextService.getSystemPrompt(sessionId);
-    if (systemPrompt != null && !systemPrompt.isEmpty()) {
+    final String userSystemPrompt = chatContextService.getSystemPrompt(sessionId);
+
+    final StringBuilder systemContent = new StringBuilder();
+    if (toolRegistry.hasTools()) {
+      systemContent.append(TOOL_USAGE_HINT);
+    }
+    if (userSystemPrompt != null && !userSystemPrompt.isEmpty()) {
+      systemContent.append(userSystemPrompt);
+    }
+
+    if (systemContent.length() > 0) {
       final List<Map<String, String>> messages = new ArrayList<>();
-      messages.add(Map.of("role", "system", Constants.CONTENT, systemPrompt));
+      messages.add(Map.of("role", "system", Constants.CONTENT, systemContent.toString()));
       messages.addAll(context);
       return messages;
     }
@@ -134,6 +157,32 @@ public class OllamaChatEngine implements ChatEngine {
   }
 
   /**
+   * Resolves the {@code arguments} field of a tool call function object into a usable Map.
+   *
+   * <p>Ollama may return {@code arguments} either as a pre-parsed JSON object (Map) or as a
+   * JSON-encoded string. Both cases are handled here so the rest of the tool-call pipeline always
+   * receives a {@code Map<String, Object>}.
+   */
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> resolveArguments(final Map<String, Object> function) {
+    final Object raw = function.getOrDefault("arguments", Map.of());
+    if (raw instanceof Map) {
+      return (Map<String, Object>) raw;
+    }
+    if (raw instanceof String) {
+      final String json = ((String) raw).trim();
+      if (!json.isEmpty()) {
+        try {
+          return MAPPER.readValue(json, Map.class);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+          LOGGER.warn("Could not parse tool arguments as JSON: {}", json);
+        }
+      }
+    }
+    return Map.of();
+  }
+
+  /**
    * Runs the tool-use loop until no tool calls remain or MAX_TOOL_ITERATIONS is reached.
    *
    * <p>When {@code emitter} is non-null, emits {@code tool_call} and {@code tool_result} named SSE
@@ -172,8 +221,7 @@ public class OllamaChatEngine implements ChatEngine {
       for (final Map<String, Object> toolCall : toolCalls) {
         final Map<String, Object> function = (Map<String, Object>) toolCall.get("function");
         final String toolName = (String) function.get("name");
-        final Map<String, Object> args =
-            (Map<String, Object>) function.getOrDefault("arguments", Map.of());
+        final Map<String, Object> args = resolveArguments(function);
         final int currentIndex = toolIndex++;
 
         if (emitter != null) {

--- a/backend/chatapp/src/main/java/com/example/chatapp/tool/WebSearchTool.java
+++ b/backend/chatapp/src/main/java/com/example/chatapp/tool/WebSearchTool.java
@@ -2,20 +2,43 @@ package com.example.chatapp.tool;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.ByteArrayInputStream;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
-/** Web search tool using the DuckDuckGo Instant Answer API. */
+/**
+ * Web search tool using a three-provider fallback chain — all free, no API keys required.
+ *
+ * <ol>
+ *   <li><b>DuckDuckGo Instant Answer API</b> — instant answers, math, units, well-known entities.
+ *   <li><b>Wikipedia REST API</b> — factual knowledge, people, places, history, concepts.
+ *   <li><b>Google News RSS</b> — current news and recent events.
+ * </ol>
+ *
+ * <p>Each provider is tried in order. The first one that returns meaningful content wins. If all
+ * three return nothing, a "no results" message is returned and the model falls back to its training
+ * data.
+ */
 @Component
 @ConditionalOnProperty(
     name = "tools.websearch.enabled",
@@ -25,10 +48,20 @@ import org.springframework.web.client.RestTemplate;
     value = {"EI_EXPOSE_REP2"},
     justification = "Spring-managed beans; RestTemplate is shared and thread-safe.")
 public class WebSearchTool implements Tool {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(WebSearchTool.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final String TOOL_NAME = "web_search";
+
   private static final String DDG_API_URL = "https://api.duckduckgo.com/";
+  private static final String WIKIPEDIA_SEARCH_URL = "https://en.wikipedia.org/w/api.php";
+  private static final String WIKIPEDIA_SUMMARY_URL =
+      "https://en.wikipedia.org/api/rest_v1/page/summary/";
+  private static final String GOOGLE_NEWS_RSS_URL = "https://news.google.com/rss/search";
+
+  /** JSON schema type keywords — used to detect when a model echoes the schema as an argument. */
+  private static final Set<String> JSON_TYPE_KEYWORDS =
+      Set.of("string", "number", "integer", "boolean", "array", "object", "null");
 
   private final RestTemplate restTemplate;
 
@@ -39,6 +72,10 @@ public class WebSearchTool implements Tool {
     this.restTemplate = restTemplate;
   }
 
+  // ---------------------------------------------------------------------------
+  // Tool interface
+  // ---------------------------------------------------------------------------
+
   @Override
   public String getName() {
     return TOOL_NAME;
@@ -46,9 +83,8 @@ public class WebSearchTool implements Tool {
 
   @Override
   public String getDescription() {
-    return "Look up a query using the DuckDuckGo Instant Answer API. Returns instant answers,"
-        + " brief summaries, and related topics for well-known entities. Does not crawl"
-        + " arbitrary web pages or retrieve real-time news.";
+    return "Search the web for current information, news, facts, and general knowledge."
+        + " Use when the user needs up-to-date information that may not be in your training data.";
   }
 
   @Override
@@ -65,40 +101,106 @@ public class WebSearchTool implements Tool {
     return schema;
   }
 
+  // ---------------------------------------------------------------------------
+  // execute
+  // ---------------------------------------------------------------------------
+
   @Override
   @SuppressWarnings({"unchecked", "PMD.AvoidCatchingGenericException"})
   public String execute(final Map<String, Object> arguments) {
-    final String query = (String) arguments.get("query");
-    if (query == null || query.isBlank()) {
+    final Object queryObj = arguments.get("query");
+    if (queryObj == null) {
       return "Error: No search query provided.";
     }
+
+    final String query;
+    if (queryObj instanceof String) {
+      query = (String) queryObj;
+    } else if (queryObj instanceof Map) {
+      // Some models return a schema-like object instead of a plain string. The actual search
+      // terms are usually in one of the string values (e.g. "description"). Take the first
+      // non-blank value that is not a JSON type keyword.
+      final String extracted =
+          ((Map<?, ?>) queryObj)
+              .values().stream()
+                  .filter(v -> v instanceof String)
+                  .map(v -> ((String) v).strip())
+                  .filter(v -> !v.isBlank() && !JSON_TYPE_KEYWORDS.contains(v.toLowerCase()))
+                  .findFirst()
+                  .orElse(null);
+      if (extracted != null) {
+        LOGGER.warn(
+            "Model passed query as schema object {}; using extracted value: {}",
+            queryObj,
+            extracted);
+        query = extracted;
+      } else {
+        LOGGER.warn("Tool received unusable argument for 'query': {}", queryObj);
+        return "Error: Could not extract a search query from the provided argument: " + queryObj;
+      }
+    } else {
+      LOGGER.warn(
+          "Tool received unexpected argument type for 'query': {}", queryObj.getClass().getName());
+      return "Error: Unexpected argument type for 'query': " + queryObj.getClass().getSimpleName();
+    }
+
+    if (query.isBlank()) {
+      return "Error: No search query provided.";
+    }
+
     LOGGER.info("Executing web search for: {}", query);
     try {
-      return searchDuckDuckGo(query);
+      // 1. DuckDuckGo Instant Answer
+      final Optional<String> ddgResult = searchDuckDuckGo(query);
+      if (ddgResult.isPresent()) {
+        return ddgResult.get();
+      }
+
+      // 2. Wikipedia
+      LOGGER.info("DuckDuckGo returned no results for '{}', trying Wikipedia", query);
+      final Optional<String> wikiResult = searchWikipedia(query);
+      if (wikiResult.isPresent()) {
+        return wikiResult.get();
+      }
+
+      // 3. Google News RSS
+      LOGGER.info("Wikipedia returned no results for '{}', trying Google News RSS", query);
+      return searchGoogleNewsRss(query).orElse("No results found for: " + query);
+
     } catch (Exception e) {
       LOGGER.error("Web search failed for query '{}': {}", query, e.getMessage(), e);
       return "Search failed: " + e.getMessage();
     }
   }
 
+  // ---------------------------------------------------------------------------
+  // Provider 1: DuckDuckGo Instant Answer API
+  // ---------------------------------------------------------------------------
+
   @SuppressWarnings({"unchecked", "PMD.LawOfDemeter"})
-  private String searchDuckDuckGo(final String query)
+  Optional<String> searchDuckDuckGo(final String query)
       throws com.fasterxml.jackson.core.JsonProcessingException, java.io.IOException {
     final String encoded = URLEncoder.encode(query, StandardCharsets.UTF_8);
     final String url = DDG_API_URL + "?q=" + encoded + "&format=json&no_html=1&skip_disambig=1";
 
-    final ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
-    final String body = response.getBody();
+    final HttpHeaders headers = new HttpHeaders();
+    headers.set(
+        HttpHeaders.USER_AGENT,
+        "Mozilla/5.0 (compatible; Boox-ChatBot/1.0; +https://github.com/boox)");
+    headers.set(HttpHeaders.ACCEPT, "application/json");
+    final HttpEntity<Void> entity = new HttpEntity<>(headers);
+    final ResponseEntity<String> response =
+        restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+
+    final String body = response != null ? response.getBody() : null;
     if (body == null || body.isEmpty()) {
-      return "No results found for: " + query;
+      return Optional.empty();
     }
 
     final Map<String, Object> json = MAPPER.readValue(body, Map.class);
-
     final StringBuilder results = new StringBuilder();
     results.append("Search results for: ").append(query).append("\n\n");
 
-    // Extract abstract (main instant answer)
     final String abstractText = (String) json.getOrDefault("AbstractText", "");
     final String abstractSource = (String) json.getOrDefault("AbstractSource", "");
     if (abstractText != null && !abstractText.isEmpty()) {
@@ -109,13 +211,11 @@ public class WebSearchTool implements Tool {
       results.append(": ").append(abstractText).append("\n\n");
     }
 
-    // Extract answer (direct answer)
     final String answer = (String) json.getOrDefault("Answer", "");
     if (answer != null && !answer.isEmpty()) {
       results.append("Answer: ").append(answer).append("\n\n");
     }
 
-    // Extract related topics
     final Object relatedTopics = json.get("RelatedTopics");
     if (relatedTopics instanceof List) {
       final List<Map<String, Object>> topics = (List<Map<String, Object>>) relatedTopics;
@@ -137,10 +237,185 @@ public class WebSearchTool implements Tool {
       }
     }
 
-    if (results.toString().equals("Search results for: " + query + "\n\n")) {
-      return "No relevant results found for: " + query;
+    final String header = "Search results for: " + query + "\n\n";
+    if (results.toString().equals(header)) {
+      return Optional.empty();
+    }
+    return Optional.of(results.toString().trim());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Provider 2: Wikipedia REST API
+  // ---------------------------------------------------------------------------
+
+  @SuppressWarnings("unchecked")
+  Optional<String> searchWikipedia(final String query)
+      throws com.fasterxml.jackson.core.JsonProcessingException, java.io.IOException {
+    // Step 1: find the most relevant article title
+    final String encoded = URLEncoder.encode(query, StandardCharsets.UTF_8);
+    final String searchUrl =
+        WIKIPEDIA_SEARCH_URL
+            + "?action=query&list=search&srsearch="
+            + encoded
+            + "&format=json&srlimit=1&srprop=snippet&utf8=1";
+
+    final HttpHeaders wikiHeaders = new HttpHeaders();
+    wikiHeaders.set(
+        HttpHeaders.USER_AGENT,
+        "Mozilla/5.0 (compatible; Boox-ChatBot/1.0; +https://github.com/boox)");
+    final HttpEntity<Void> entity = new HttpEntity<>(wikiHeaders);
+    final ResponseEntity<String> searchResponse =
+        restTemplate.exchange(searchUrl, HttpMethod.GET, entity, String.class);
+
+    final String searchBody = searchResponse != null ? searchResponse.getBody() : null;
+    if (searchBody == null || searchBody.isEmpty()) {
+      return Optional.empty();
     }
 
-    return results.toString().trim();
+    final Map<String, Object> searchJson = MAPPER.readValue(searchBody, Map.class);
+    final Map<String, Object> queryObj = (Map<String, Object>) searchJson.get("query");
+    if (queryObj == null) {
+      return Optional.empty();
+    }
+    final List<Map<String, Object>> searchResults =
+        (List<Map<String, Object>>) queryObj.get("search");
+    if (searchResults == null || searchResults.isEmpty()) {
+      return Optional.empty();
+    }
+
+    final String articleTitle = (String) searchResults.get(0).get("title");
+    if (articleTitle == null || articleTitle.isEmpty()) {
+      return Optional.empty();
+    }
+
+    // Step 2: fetch the article summary
+    final String normalizedTitle = articleTitle.replace(' ', '_');
+    final String summaryUrl =
+        WIKIPEDIA_SUMMARY_URL + URLEncoder.encode(normalizedTitle, StandardCharsets.UTF_8);
+
+    final ResponseEntity<String> summaryResponse =
+        restTemplate.exchange(summaryUrl, HttpMethod.GET, entity, String.class);
+
+    final String summaryBody = summaryResponse != null ? summaryResponse.getBody() : null;
+    if (summaryBody == null || summaryBody.isEmpty()) {
+      return Optional.empty();
+    }
+
+    final Map<String, Object> summaryJson = MAPPER.readValue(summaryBody, Map.class);
+    final String extract = (String) summaryJson.getOrDefault("extract", "");
+    if (extract == null || extract.isBlank()) {
+      return Optional.empty();
+    }
+
+    // Trim to first paragraph or 600 chars, whichever is shorter
+    final String firstParagraph =
+        extract.contains("\n") ? extract.substring(0, extract.indexOf('\n')) : extract;
+    final String summary =
+        firstParagraph.length() > 600 ? firstParagraph.substring(0, 600) + "..." : firstParagraph;
+
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> contentUrls =
+        (Map<String, Object>) summaryJson.getOrDefault("content_urls", Map.of());
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> desktop =
+        (Map<String, Object>) contentUrls.getOrDefault("desktop", Map.of());
+    final String pageUrl = (String) desktop.getOrDefault("page", "");
+
+    final StringBuilder result = new StringBuilder();
+    result.append("Wikipedia: ").append(articleTitle).append("\n\n");
+    result.append(summary);
+    if (!pageUrl.isEmpty()) {
+      result.append("\n\nSource: ").append(pageUrl);
+    }
+    return Optional.of(result.toString().trim());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Provider 3: Google News RSS
+  // ---------------------------------------------------------------------------
+
+  @SuppressFBWarnings(
+      value = "XXE_DOCUMENT_BUILDER_FACTORY",
+      justification = "XXE is disabled via setFeature calls below.")
+  Optional<String> searchGoogleNewsRss(final String query) throws Exception {
+    final String encoded = URLEncoder.encode(query, StandardCharsets.UTF_8);
+    final String url = GOOGLE_NEWS_RSS_URL + "?q=" + encoded + "&hl=en-US&gl=US&ceid=US:en";
+
+    final HttpHeaders headers = new HttpHeaders();
+    headers.set(
+        HttpHeaders.USER_AGENT,
+        "Mozilla/5.0 (compatible; Boox-ChatBot/1.0; +https://github.com/boox)");
+    final HttpEntity<Void> entity = new HttpEntity<>(headers);
+    final ResponseEntity<String> response =
+        restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+
+    final String body = response != null ? response.getBody() : null;
+    if (body == null || body.isEmpty()) {
+      return Optional.empty();
+    }
+
+    // Parse RSS XML — disable XXE for security
+    final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setExpandEntityReferences(false);
+
+    final DocumentBuilder builder = factory.newDocumentBuilder();
+    final Document doc =
+        builder.parse(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+
+    final NodeList items = doc.getElementsByTagName("item");
+    if (items.getLength() == 0) {
+      return Optional.empty();
+    }
+
+    final StringBuilder results = new StringBuilder();
+    results.append("News results for: ").append(query).append("\n\n");
+
+    final int limit = Math.min(items.getLength(), maxResults);
+    for (int i = 0; i < limit; i++) {
+      final Element item = (Element) items.item(i);
+      final String title = getXmlText(item, "title");
+      final String link = getXmlText(item, "link");
+      final String pubDate = getXmlText(item, "pubDate");
+
+      if (!title.isEmpty()) {
+        results.append(i + 1).append(". ").append(title).append("\n");
+        if (!pubDate.isEmpty()) {
+          results.append("   ").append(pubDate).append("\n");
+        }
+        if (!link.isEmpty()) {
+          results.append("   ").append(link).append("\n");
+        }
+        results.append("\n");
+      }
+    }
+
+    final String header = "News results for: " + query + "\n\n";
+    if (results.toString().equals(header)) {
+      return Optional.empty();
+    }
+    return Optional.of(results.toString().trim());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Utilities
+  // ---------------------------------------------------------------------------
+
+  private static String getXmlText(final Element parent, final String tagName) {
+    final NodeList nodes = parent.getElementsByTagName(tagName);
+    if (nodes.getLength() == 0) {
+      return "";
+    }
+    final String text = nodes.item(0).getTextContent();
+    return text == null ? "" : text.trim();
+  }
+
+  static String stripHtml(final String html) {
+    if (html == null) {
+      return "";
+    }
+    return html.replaceAll("<[^>]+>", "").trim();
   }
 }

--- a/backend/chatapp/src/main/resources/application.properties
+++ b/backend/chatapp/src/main/resources/application.properties
@@ -24,3 +24,9 @@ ollama.model.description=Ollama model
 # Tool configuration
 tools.websearch.enabled=true
 tools.websearch.max-results=5
+# Google Custom Search API (optional — enables full web search)
+# Get a free API key: https://developers.google.com/custom-search/v1/introduction
+# Get a Search Engine ID: https://programmablesearchengine.google.com/
+# Free tier: 100 queries/day. Without these, falls back to DuckDuckGo Instant Answer API.
+tools.websearch.google.api-key=${GOOGLE_API_KEY:}
+tools.websearch.google.search-engine-id=${GOOGLE_SEARCH_ENGINE_ID:}

--- a/backend/chatapp/src/test/java/com/example/chatapp/tool/WebSearchToolTest.java
+++ b/backend/chatapp/src/test/java/com/example/chatapp/tool/WebSearchToolTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
@@ -23,10 +25,11 @@ class WebSearchToolTest {
 
   WebSearchTool tool;
 
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
   @BeforeEach
   void setUp() {
     tool = new WebSearchTool(restTemplate);
-    // Set @Value fields via reflection
     setField(tool, "maxResults", 5);
   }
 
@@ -39,6 +42,43 @@ class WebSearchToolTest {
       throw new RuntimeException(e);
     }
   }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private ResponseEntity<String> jsonResponse(Object obj) throws Exception {
+    return new ResponseEntity<>(MAPPER.writeValueAsString(obj), HttpStatus.OK);
+  }
+
+  private ResponseEntity<String> emptyDdgResponse() throws Exception {
+    return jsonResponse(Map.of("AbstractText", "", "Answer", "", "RelatedTopics", List.of()));
+  }
+
+  private ResponseEntity<String> emptyWikiSearchResponse() throws Exception {
+    return jsonResponse(Map.of("query", Map.of("search", List.of())));
+  }
+
+  /** Stubs DuckDuckGo URL to return an empty-results response. */
+  private void stubDdgEmpty() throws Exception {
+    when(restTemplate.exchange(
+            contains("duckduckgo.com"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(String.class)))
+        .thenReturn(emptyDdgResponse());
+  }
+
+  /** Stubs Wikipedia search and summary URLs to return empty results. */
+  private void stubWikiEmpty() throws Exception {
+    when(restTemplate.exchange(
+            contains("w/api.php"), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+        .thenReturn(emptyWikiSearchResponse());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Metadata
+  // ---------------------------------------------------------------------------
 
   @Test
   void getName_returnsWebSearch() {
@@ -54,13 +94,53 @@ class WebSearchToolTest {
   void getParameterSchema_hasQueryProperty() {
     Map<String, Object> schema = tool.getParameterSchema();
     assertEquals("object", schema.get("type"));
+    @SuppressWarnings("unchecked")
     Map<String, Object> props = (Map<String, Object>) schema.get("properties");
     assertTrue(props.containsKey("query"));
   }
 
+  // ---------------------------------------------------------------------------
+  // Argument validation
+  // ---------------------------------------------------------------------------
+
   @Test
-  void execute_returnsResults_whenDdgReturnsData() throws Exception {
-    // Arrange
+  void execute_returnsError_whenQueryBlank() {
+    assertTrue(tool.execute(Map.of("query", "")).startsWith("Error"));
+  }
+
+  @Test
+  void execute_returnsError_whenQueryMissing() {
+    assertTrue(tool.execute(Map.of()).startsWith("Error"));
+  }
+
+  @Test
+  void execute_extractsQueryFromSchemaObject_andSearches() throws Exception {
+    // Model returns {description="cats", type="string"} — should extract "cats" and search
+    Map<String, Object> ddgResponse =
+        Map.of("AbstractText", "Cats are mammals.", "AbstractSource", "Wikipedia");
+    when(restTemplate.exchange(
+            contains("duckduckgo.com"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(String.class)))
+        .thenReturn(jsonResponse(ddgResponse));
+
+    String result = tool.execute(Map.of("query", Map.of("description", "cats", "type", "string")));
+    assertTrue(result.contains("Cats are mammals."));
+  }
+
+  @Test
+  void execute_returnsError_whenSchemaObjectHasNoUsableValue() {
+    // Only type keyword values present — nothing to extract
+    assertTrue(tool.execute(Map.of("query", Map.of("type", "string"))).startsWith("Error"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Provider 1: DuckDuckGo
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void execute_ddg_returnsAbstractText() throws Exception {
     Map<String, Object> ddgResponse =
         Map.of(
             "AbstractText", "Cats are domesticated mammals.",
@@ -69,75 +149,160 @@ class WebSearchToolTest {
                 List.of(
                     Map.of(
                         "Text",
-                        "Cat - Wikipedia",
+                        "Cat - a domestic animal",
                         "FirstURL",
                         "https://en.wikipedia.org/wiki/Cat")));
-    String json = new ObjectMapper().writeValueAsString(ddgResponse);
-    when(restTemplate.getForEntity(anyString(), eq(String.class)))
-        .thenReturn(new ResponseEntity<>(json, HttpStatus.OK));
+    when(restTemplate.exchange(
+            contains("duckduckgo.com"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(String.class)))
+        .thenReturn(jsonResponse(ddgResponse));
 
-    // Act
     String result = tool.execute(Map.of("query", "cats"));
-
-    // Assert
-    assertTrue(result.contains("cats"));
     assertTrue(result.contains("Cats are domesticated mammals."));
     assertTrue(result.contains("Wikipedia"));
   }
 
   @Test
-  void execute_returnsNoResults_whenDdgReturnsEmpty() throws Exception {
-    // Arrange
-    Map<String, Object> ddgResponse = Map.of("AbstractText", "", "Answer", "");
-    String json = new ObjectMapper().writeValueAsString(ddgResponse);
-    when(restTemplate.getForEntity(anyString(), eq(String.class)))
-        .thenReturn(new ResponseEntity<>(json, HttpStatus.OK));
+  void execute_ddg_returnsAnswer() throws Exception {
+    Map<String, Object> ddgResponse = Map.of("AbstractText", "", "Answer", "42");
+    when(restTemplate.exchange(
+            contains("duckduckgo.com"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(String.class)))
+        .thenReturn(jsonResponse(ddgResponse));
 
-    // Act
-    String result = tool.execute(Map.of("query", "xyznonexistent"));
-
-    // Assert
-    assertTrue(result.contains("No relevant results"));
+    assertTrue(tool.execute(Map.of("query", "meaning of life")).contains("Answer: 42"));
   }
 
   @Test
-  void execute_returnsError_whenQueryBlank() {
-    String result = tool.execute(Map.of("query", ""));
-    assertTrue(result.contains("Error"));
-  }
-
-  @Test
-  void execute_returnsError_whenQueryNull() {
-    String result = tool.execute(Map.of());
-    assertTrue(result.contains("Error"));
-  }
-
-  @Test
-  void execute_returnsError_whenApiThrows() {
-    when(restTemplate.getForEntity(anyString(), eq(String.class)))
+  void execute_ddg_returnsSearchFailed_whenApiThrows() {
+    when(restTemplate.exchange(
+            contains("duckduckgo.com"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(String.class)))
         .thenThrow(new RuntimeException("Connection refused"));
 
-    String result = tool.execute(Map.of("query", "test"));
-    assertTrue(result.contains("Search failed"));
+    assertTrue(tool.execute(Map.of("query", "test")).contains("Search failed"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Provider 2: Wikipedia fallback
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void execute_wikipedia_usedWhenDdgReturnsEmpty() throws Exception {
+    stubDdgEmpty();
+
+    Map<String, Object> wikiSearch =
+        Map.of("query", Map.of("search", List.of(Map.of("title", "Prime Minister of India"))));
+    when(restTemplate.exchange(
+            contains("w/api.php"), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+        .thenReturn(jsonResponse(wikiSearch));
+
+    Map<String, Object> wikiSummary =
+        Map.of(
+            "title",
+            "Prime Minister of India",
+            "extract",
+            "The Prime Minister of India is the head of government. Narendra Modi"
+                + " has been the current PM since 2014.",
+            "content_urls",
+            Map.of(
+                "desktop",
+                Map.of("page", "https://en.wikipedia.org/wiki/Prime_Minister_of_India")));
+    when(restTemplate.exchange(
+            contains("rest_v1/page/summary"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(String.class)))
+        .thenReturn(jsonResponse(wikiSummary));
+
+    String result = tool.execute(Map.of("query", "prime minister of india"));
+    assertTrue(result.contains("Prime Minister of India"));
+    assertTrue(result.contains("Narendra Modi"));
+    assertTrue(result.contains("wikipedia.org"));
   }
 
   @Test
-  void execute_handlesNullBody() {
-    when(restTemplate.getForEntity(anyString(), eq(String.class)))
+  void execute_wikipedia_skippedWhenSearchReturnsEmpty() throws Exception {
+    stubDdgEmpty();
+    stubWikiEmpty();
+
+    // Google News RSS also returns nothing
+    when(restTemplate.exchange(
+            contains("news.google.com"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(String.class)))
         .thenReturn(new ResponseEntity<>(null, HttpStatus.OK));
 
-    String result = tool.execute(Map.of("query", "test"));
+    String result = tool.execute(Map.of("query", "xyznonexistent"));
     assertTrue(result.contains("No results found"));
   }
 
-  @Test
-  void execute_extractsAnswer() throws Exception {
-    Map<String, Object> ddgResponse = Map.of("AbstractText", "", "Answer", "42");
-    String json = new ObjectMapper().writeValueAsString(ddgResponse);
-    when(restTemplate.getForEntity(anyString(), eq(String.class)))
-        .thenReturn(new ResponseEntity<>(json, HttpStatus.OK));
+  // ---------------------------------------------------------------------------
+  // Provider 3: Google News RSS fallback
+  // ---------------------------------------------------------------------------
 
-    String result = tool.execute(Map.of("query", "meaning of life"));
-    assertTrue(result.contains("Answer: 42"));
+  @Test
+  void execute_newsRss_usedWhenDdgAndWikiReturnEmpty() throws Exception {
+    stubDdgEmpty();
+    stubWikiEmpty();
+
+    String rssXml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<rss version=\"2.0\"><channel>"
+            + "<item>"
+            + "<title>Modi announces new policy - BBC News</title>"
+            + "<link>https://news.google.com/rss/articles/test</link>"
+            + "<pubDate>Sat, 22 Feb 2026 12:00:00 GMT</pubDate>"
+            + "</item>"
+            + "</channel></rss>";
+    when(restTemplate.exchange(
+            contains("news.google.com"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(String.class)))
+        .thenReturn(new ResponseEntity<>(rssXml, HttpStatus.OK));
+
+    String result = tool.execute(Map.of("query", "india news"));
+    assertTrue(result.contains("Modi announces new policy"));
+    assertTrue(result.contains("BBC News"));
+  }
+
+  @Test
+  void execute_newsRss_returnsNoResults_whenRssHasNoItems() throws Exception {
+    stubDdgEmpty();
+    stubWikiEmpty();
+
+    String emptyRss =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<rss version=\"2.0\"><channel></channel></rss>";
+    when(restTemplate.exchange(
+            contains("news.google.com"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(String.class)))
+        .thenReturn(new ResponseEntity<>(emptyRss, HttpStatus.OK));
+
+    assertTrue(tool.execute(Map.of("query", "xyznotfound")).contains("No results found"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // stripHtml utility
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void stripHtml_removesTagsAndTrims() {
+    assertEquals("hello world", WebSearchTool.stripHtml("<b>hello</b> <i>world</i>"));
+  }
+
+  @Test
+  void stripHtml_handlesNull() {
+    assertEquals("", WebSearchTool.stripHtml(null));
   }
 }


### PR DESCRIPTION
## Summary

- **3-provider fallback chain** (DuckDuckGo → Wikipedia → Google News RSS) replaces
  the single DuckDuckGo Instant Answer call — real-time queries (sports results, news,
  current events) now always get a useful answer with zero API keys required
- **Fix 403 errors** from DuckDuckGo and Wikipedia by sending a proper `User-Agent`
  header on every outbound HTTP request
- **Robust tool argument handling** — guards against the model echoing the parameter
  schema as the argument value; also handles arguments arriving as a JSON-encoded
  String instead of a pre-parsed Map
- **`TOOL_USAGE_HINT` in system prompt** — discourages smaller models (llama3.2 3B)
  from calling tools for greetings or questions answerable from training data
- **XXE-hardened XML parsing** in the Google News RSS reader

## Test plan

- [x] All 64 backend unit tests pass (`mvn test` — 0 failures)
- [x] Ask the bot a real-time question (e.g. latest sports result or news headline)
      — should return a Wikipedia or Google News answer when DuckDuckGo has no instant answer
- [x] Ask the bot "hi there" — should NOT trigger a web search tool call
- [x] No 403 errors in logs for DuckDuckGo or Wikipedia requests
