### PR TITLE
chore: update default model to phi4-mini

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.gitignore
+.idea
+.vscode
+.DS_Store
+**/node_modules
+**/build
+**/dist
+**/target
+*.log
+.env.local
+.env.*.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
             docker compose -f docker-compose.boox.yml up
             ```
 
-            - The default AI model (`llama3.2:1b`, ~1.3 GB) downloads automatically on first run.
+            - The default AI model (`phi4-mini`, ~2.5 GB) downloads automatically on first run.
             - The model is cached in a Docker volume — subsequent starts are instant.
             - To use a different model, set `OLLAMA_MODEL` in a `.env` file next to the compose file.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Boox is a full-stack web application providing an interactive chat UI powered by
 |---|---|
 | Frontend | React 17, Axios, react-scripts |
 | Backend | Spring Boot 2.6.6, Java 17, Maven |
-| AI Engine | Ollama (llama3.2 default) |
+| AI Engine | Ollama (phi4-mini default) |
 | HTTP Client | Spring Cloud OpenFeign |
 | Containerization | Docker, Docker Compose |
 
@@ -26,14 +26,14 @@ Boox is a full-stack web application providing an interactive chat UI powered by
 ```bash
 docker compose up -d
 # Pull a model into the ollama container:
-docker exec <ollama_container_id> ollama pull llama3.2
+docker exec <ollama_container_id> ollama pull phi4-mini
 # App available at http://localhost:8080
 ```
 
 ### Local Development
 ```bash
 # Terminal 1 — Ollama
-ollama serve && ollama pull llama3.2
+ollama serve && ollama pull phi4-mini
 
 # Terminal 2 — Backend (port 8080)
 cd backend/chatapp && mvn spring-boot:run
@@ -109,7 +109,7 @@ Key properties (`backend/chatapp/src/main/resources/application.properties`):
 ```properties
 server.port=8080
 ollama.api.url=http://localhost:11434
-ollama.model=llama3.2
+ollama.model=phi4-mini
 ollama.api.temperature=0.7
 chat.cors.allowed-origins=http://localhost:3000
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ docker compose -f docker-compose.boox.yml up
 
 Open **http://localhost:8080** — done.
 
-> The default AI model (`llama3.2:1b`, ~1.3 GB) is pulled automatically on first run and cached in
+> The default AI model (`phi4-mini`, ~2.5 GB) is pulled automatically on first run and cached in
 > a Docker volume. Subsequent starts are instant. To use a different model, create a `.env` file
 > next to the compose file with `OLLAMA_MODEL=<model-name>`.
 
@@ -32,7 +32,7 @@ For local development:
 - Java 17
 - Node.js 20+
 - Maven
-- [Ollama](https://ollama.ai/) with your preferred model (default: llama3.2)
+- [Ollama](https://ollama.ai/) with your preferred model (default: phi4-mini)
 
 ## Development Options
 
@@ -53,14 +53,14 @@ docker compose up -d
 docker compose logs -f
 ```
 
-After the containers are up and running, you'll need to download the llama3.2 model:
+After the containers are up and running, you'll need to download the phi4-mini model:
 
 ```bash
 # Get the Ollama container ID
 docker compose ps
 
-# Download the llama3.2 model
-docker exec <ollama_container_id> ollama pull llama3.2
+# Download the phi4-mini model
+docker exec <ollama_container_id> ollama pull phi4-mini
 ```
 
 The Ollama model will be cached in a Docker volume and won't need to be downloaded again.
@@ -80,10 +80,10 @@ docker exec <ollama_container_id> ollama pull <model_name>
 1. Start Ollama server and pull the model:
 ```bash
 ollama serve
-ollama pull llama2
+ollama pull phi4-mini
 ```
 
-You can download a different model by replacing `llama2` with your desired model name. Be considerate of your system resources, as some models can be quite large.
+You can download a different model by replacing `phi4-mini` with your desired model name. Be considerate of your system resources, as some models can be quite large.
 
 2. Start the backend:
 ```bash
@@ -105,7 +105,7 @@ If you prefer to run Ollama locally (useful if you use Ollama for other projects
 1. Start Ollama locally and pull the model:
 ```bash
 ollama serve
-ollama pull llama2
+ollama pull phi4-mini
 ```
 
 2. Run the Boox container with host network access:
@@ -114,7 +114,7 @@ docker run -d --name boox_app \
   -p 3000:3000 \
   -p 8080:8080 \
   -e OLLAMA_API_URL=http://host.docker.internal:11434 \
-  -e OLLAMA_MODEL=llama2 \
+  -e OLLAMA_MODEL=phi4-mini \
   boox
 ```
 
@@ -155,14 +155,14 @@ docker run -d --name boox_app \
   -p 3000:3000 \
   -p 8080:8080 \
   -e OLLAMA_API_URL=http://ollama:11434 \
-  -e OLLAMA_MODEL=llama2 \
+  -e OLLAMA_MODEL=phi4-mini \
   -e OLLAMA_API_TEMPERATURE=0.7 \
   boox
 ```
 
 Available variables:
 - `OLLAMA_API_URL`: Ollama server URL
-- `OLLAMA_MODEL`: AI model to use (default: llama2)
+- `OLLAMA_MODEL`: AI model to use (default: phi4-mini)
 - `OLLAMA_API_TEMPERATURE`: Model temperature (default: 0.7)
 - `PORT`: Backend port (default: 8080)
 - `CORS_ALLOWED_ORIGINS`: CORS origins (default: http://localhost:3000)

--- a/backend/chatapp/src/main/resources/application-docker.properties
+++ b/backend/chatapp/src/main/resources/application-docker.properties
@@ -5,7 +5,7 @@ server.port=8080
 ollama.api.url=http://host.docker.internal:11434
 
 # Ollama Configuration
-ollama.model=${OLLAMA_MODEL:llama3.2}
+ollama.model=${OLLAMA_MODEL:phi4-mini}
 ollama.api.temperature=${OLLAMA_API_TEMPERATURE:0.7}
 ollama.api.tags-path=/api/tags
 ollama.api.chat-path=/api/chat

--- a/backend/chatapp/src/main/resources/application.properties
+++ b/backend/chatapp/src/main/resources/application.properties
@@ -9,7 +9,7 @@ server.port=${PORT:8080}
 
 # Ollama Configuration
 ollama.api.url=${OLLAMA_API_URL:http://localhost:11434}
-ollama.model=${OLLAMA_MODEL:llama3.2}
+ollama.model=${OLLAMA_MODEL:phi4-mini}
 ollama.api.temperature=${OLLAMA_API_TEMPERATURE:0.7}
 
 logging.level.com.example.chatapp=INFO

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -10,7 +10,7 @@
 #   docker compose -f docker-compose.boox.yml up
 #
 # Open http://localhost:8080 — no further configuration needed.
-# The AI model (~1.3 GB) is downloaded once and cached in a Docker volume.
+# The AI model (~2.5 GB) is downloaded once and cached in a Docker volume.
 
 services:
 
@@ -45,7 +45,7 @@ services:
         condition: service_healthy
     environment:
       - OLLAMA_HOST=http://ollama:11434
-    entrypoint: ["ollama", "pull", "llama3.2:1b"]
+    entrypoint: ["ollama", "pull", "phi4-mini"]
     volumes:
       - ollama_data:/root/.ollama
     restart: "no"
@@ -57,7 +57,7 @@ services:
       - "8080:8080"
     environment:
       - OLLAMA_API_URL=http://ollama:11434
-      - OLLAMA_MODEL=llama3.2:1b
+      - OLLAMA_MODEL=phi4-mini
       - OLLAMA_API_TEMPERATURE=0.7
       - PORT=8080
       - CORS_ALLOWED_ORIGINS=http://localhost:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "8080:8080"
     environment:
       - OLLAMA_API_URL=http://ollama:11434
-      - OLLAMA_MODEL=llama3.2
+      - OLLAMA_MODEL=phi4-mini
       - OLLAMA_API_TEMPERATURE=0.7
       - CORS_ALLOWED_ORIGINS=http://localhost:3000
       - PORT=8080
@@ -30,7 +30,7 @@ services:
         reservations:
           memory: 4G
     environment:
-      - OLLAMA_MODEL=llama3.2
+      - OLLAMA_MODEL=phi4-mini
 
 volumes:
   ollama_data: 

--- a/frontend/src/components/ChatBox.jsx
+++ b/frontend/src/components/ChatBox.jsx
@@ -34,7 +34,7 @@ const ChatBox = ({ selectedServer, setSelectedServer, servers }) => {
             try {
                 const result = await getModels(selectedServer);
                 setModels(result);
-                const defaultModel = result.find(m => m.name === 'llama3.2:latest');
+                const defaultModel = result.find(m => m.name === 'phi4-mini:latest');
                 if (defaultModel) {
                     setSelectedModel(defaultModel.name);
                 }


### PR DESCRIPTION
## Summary

- Replace all `llama3.2` / `llama2` default model references with `phi4-mini` (Microsoft, 3.8B, ~2.5 GB)
- Update size annotations in `docker-compose.release.yml` and README (1.3 GB → 2.5 GB)
- Fix release workflow release notes body (was still referencing `llama3.2:1b`)
- Add `.dockerignore` (was untracked)

**Why phi4-mini over llama3.2:3b?** For ~500 MB extra, phi4-mini delivers significantly better reasoning and coding performance (67.3% MMLU vs ~58%, 74.4% HumanEval), rivals some 7B models, and is MIT licensed with 128K context — best practical choice for a local laptop chatbot.

## Test plan

- [ ] `ollama pull phi4-mini` works locally
- [ ] App auto-selects `phi4-mini:latest` in the model dropdown on server connect
- [ ] CI passes (backend build + quality gates, frontend tests, Dockerfile lint)
- [ ] After merge: tag `v1.2.0` and push to trigger release pipeline → Docker Hub + GitHub Release